### PR TITLE
Add AdGenius marketing assistant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ use cases. Specifically:
 - [Answering complex, multi-step questions with agents](/app/api/chat/agents/route.ts)
 - [Retrieval augmented generation (RAG) with a chain and a vector store](/app/api/chat/retrieval/route.ts)
 - [Retrieval augmented generation (RAG) with an agent and a vector store](/app/api/chat/retrieval_agents/route.ts)
+- [AdGenius marketing assistant](/app/api/adgenius/route.ts)
 
 Most of them use Vercel's [AI SDK](https://github.com/vercel-labs/ai) to stream tokens to the client and display the incoming messages.
 

--- a/app/adgenius/page.tsx
+++ b/app/adgenius/page.tsx
@@ -1,0 +1,29 @@
+import { ChatWindow } from "@/components/ChatWindow";
+import { GuideInfoBox } from "@/components/guide/GuideInfoBox";
+
+export default function AdGeniusPage() {
+  const InfoCard = (
+    <GuideInfoBox>
+      <ul>
+        <li className="text-l">
+          💡<span className="ml-2">Chat with AdGenius to build your Google Ads campaigns.</span>
+        </li>
+        <li className="hidden text-l md:block">
+          💻<span className="ml-2">Prompt logic located in <code>app/api/adgenius/route.ts</code>.</span>
+        </li>
+        <li className="text-l">
+          👇<span className="ml-2">Ask for keywords, budgets, or ad copy ideas!</span>
+        </li>
+      </ul>
+    </GuideInfoBox>
+  );
+
+  return (
+    <ChatWindow
+      endpoint="api/adgenius"
+      emptyStateComponent={InfoCard}
+      placeholder="Ask AdGenius for help with your ad campaign..."
+      emoji="💼"
+    />
+  );
+}

--- a/app/api/adgenius/route.ts
+++ b/app/api/adgenius/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Message as VercelChatMessage, StreamingTextResponse } from "ai";
+
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { HttpResponseOutputParser } from "langchain/output_parsers";
+
+export const runtime = "edge";
+
+const formatMessage = (message: VercelChatMessage) => {
+  return `${message.role}: ${message.content}`;
+};
+
+const TEMPLATE = `You are AdGenius, an AI marketing assistant that helps small business owners create and optimize Google Ads campaigns. Speak in plain English and provide clear, actionable advice. Offer keyword suggestions, ad copy ideas and budget recommendations when relevant.
+
+Current conversation:
+{chat_history}
+
+User: {input}
+AI:`;
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const messages = body.messages ?? [];
+    const formattedPreviousMessages = messages.slice(0, -1).map(formatMessage);
+    const currentMessageContent = messages[messages.length - 1].content;
+    const prompt = PromptTemplate.fromTemplate(TEMPLATE);
+
+    const model = new ChatOpenAI({
+      temperature: 0.7,
+      model: "gpt-4o-mini",
+    });
+
+    const outputParser = new HttpResponseOutputParser();
+    const chain = prompt.pipe(model).pipe(outputParser);
+
+    const stream = await chain.stream({
+      chat_history: formattedPreviousMessages.join("\n"),
+      input: currentMessageContent,
+    });
+
+    return new StreamingTextResponse(stream);
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: e.status ?? 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -81,6 +81,7 @@ export default function RootLayout({
                   <ActiveLink href="/retrieval_agents">
                     🤖 Retrieval Agents
                   </ActiveLink>
+                  <ActiveLink href="/adgenius">💼 AdGenius</ActiveLink>
                   <ActiveLink href="/ai_sdk">
                     🌊 React Server Components
                   </ActiveLink>


### PR DESCRIPTION
## Summary
- create `/app/api/adgenius/route.ts` with marketing assistant prompt
- expose new `/adgenius` page that uses a ChatWindow
- link to the new page from the navigation bar
- document the new example in the README

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.5.1/...)*